### PR TITLE
Support for optional Basic Realm for Www-Authenticate header

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let router = Router(middleware: basicAuth) { route in
 }
 ```
 
-If you want the browser to show a login prompt after receiving a 401 Access Denied, you can set an optional `Basic realm` for the `WWW-Authenticate`.
+If you want the browser to show a login prompt after receiving `Access Denied`, you can set an optional `Basic realm` for the `WWW-Authenticate` header.
 
 ```swift
 let basicAuth = BasicAuthMiddleware(realm: "Password Protected Realm") { username, password in

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ let router = Router(middleware: basicAuth) { route in
 }
 ```
 
+If you want the browser to show a login prompt after receiving a 401 Access Denied, you can set an optional `Basic realm` for the `WWW-Authenticate`.
+
+```swift
+let basicAuth = BasicAuthMiddleware(realm: "Password Protected Realm") { username, password in
+    if username == "admin" && password == "password" {
+        return .Authenticated
+    }
+
+    return .AccessDenied
+}
+```
+
 ### Client
 
 ```swift


### PR DESCRIPTION
If you want the browser to show a login popup, and allow the client to store the credentials for a realm, a 401 response needs to come with a `WWW-Authenticate: Basic realm="the basic realm"` header. 

This patch should add support for this. See the README for the syntax.  
